### PR TITLE
GA4 Setup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,5 +55,5 @@ facebook-pixel: ""
 resources_name: resource-room
 shareicon: /images/isomer-logo.svg
 is_government: false
-google_analytics_ga4: ""
+google_analytics_ga4: G-C0MNMG9DP6
 linkedin-insights: ""


### PR DESCRIPTION
Added Google Analytics measurement ID under the Google Analytics (GA4) Field in the website's Site Settings page